### PR TITLE
fix: configure GitHub avatars hostname for Next.js Image component

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
+  },
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- Add avatars.githubusercontent.com to remotePatterns in next.config.js
- Fixes 'Invalid src prop' error when displaying profile avatar

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)